### PR TITLE
Custom error message for unique email

### DIFF
--- a/app/validators/newsletter.ts
+++ b/app/validators/newsletter.ts
@@ -8,12 +8,9 @@ const properties = {
     .trim()
     .minLength(4)
     .maxLength(256)
-    .unique(async (db, value, field) => {
-      const emailExists = await db.from('newsletters').where('email', value).first()
-      if (emailExists) {
-        field.report('', 'unique', field)
-      }
-      return !emailExists
+    .unique({
+      table: 'newsletters',
+      column: 'email',
     })
     .normalizeEmail({
       all_lowercase: true,

--- a/start/validator.ts
+++ b/start/validator.ts
@@ -2,6 +2,6 @@ import vine, { SimpleMessagesProvider } from '@vinejs/vine'
 
 vine.messagesProvider = new SimpleMessagesProvider({
   // Applicable for all fields
-  'email.unique': "Un compte s'est déjà inscrit avec cette adresse email",
+  'email.database.unique': "Un compte s'est déjà inscrit avec cette adresse email",
   'email.email': 'Le champs email doit être une adresse email valide !',
 })


### PR DESCRIPTION
Ce n'est spécifié nulle part mais en regardant le code de Lucid j'ai vu qu'ils faisaient un report de la clé `database.unique` [link](https://github.com/adonisjs/lucid/blob/21.x/src/bindings/vinejs.ts).

Donc en utilisant la clé `email.database.unique` il est possible d'override le message ce qui évite d'avoir à faire ça `field.report('', 'unique', field)`.